### PR TITLE
Adding explanatory text to coal-phase-out-eu.md 

### DIFF
--- a/collections/_infographics/energy/coal-phase-out-eu.md
+++ b/collections/_infographics/energy/coal-phase-out-eu.md
@@ -3,7 +3,7 @@ layout:        infographic
 title:         "Coal phase-out in the EU countries"
 slug:          "coal-phase-out-eu"
 redirect_from: "/coal-phase-out-eu"
-published:     2022-07-26
+published:     2022-11-27
 weight:        90
 tags-scopes:   [ eu ]
 tags-topics:   [ energy, policies ]
@@ -15,4 +15,49 @@ data-orig:
   - [ "UN (population)", "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/EXCEL_FILES/1_Population/WPP2019_POP_F01_1_TOTAL_POPULATION_BOTH_SEXES.xlsx" ]
 ---
 
-{% include includes-local/comment-placeholder.md slug="infografiky/uhelny-phaseout-eu" %}
+## How to read this graph
+
+* **What is a coal phase-out?** It is the complete phase-out of coal-fired electricity generation and the replacement of this generation by sources with significantly lower emissions intensity.
+
+* **Coal production per person** – The left-hand side of the graphic shows the annual electricity generation from coal power plants based on the country's population [<glossary id="w" >kWh/capita</glossary>] for 2019. This graphic also determines the ranking of the countries shown. In the Czech Republic, electricity generation from coal per capita was the highest in the EU that year (the same applies to the installed capacity of coal power plants per person).
+
+* **Share of coal in electricity production** – to the left of the per-person coal generation data are values indicating the share of electricity generation from coal in the country's energy mix. In Poland, for example, this share is 74%. Thus, the coal phase-out will be a much bigger challenge for Poland than, e.g. France, where coal-fired electricity generation accounted for less than 1% of total electricity generation in 2019.
+
+* **Coal phase-out status** - countries are colour-coded in the overview according to their current coal phase-out status. In Belgium, Austria, Sweden and Portugal, the phase-out has already been completed, and all other EU countries except Poland have a specific date when this will happen. The so-called Coal Commission has recommended a coal phase-out in the Czech Republic by 2038. However, the current government has signed up for 2033 in its January 2022 programme statement. Although Poland has signed an agreement with mining unions to support coal mining until 2049, there is still no official discussion on the date at the national level. The map on the right of the graphic shows the division of Europe into country blocks according to their status.
+
+* **Planned coal phase-out date** – indicates the year by which countries have committed to phasing out coal from their energy mix. I.e., the latest date by which the last coal power plant should be shut down.
+
+## Comments on the graph
+
+**Countries with negligible coal capacity** - a special category represents European countries that have never had coal capacity (or, in their case, it is negligible). In practice, however, this does not mean that they are not affected by the energy transition:
+
+* Some of them depend heavily on other fossil fuels for electricity production. Cyprus relies 95% on electricity generation from liquid fuels. Malta generates about 80% of its domestic electricity from natural gas. Estonia produces 70% of its electricity by burning oil shale (newly in 2019, a smaller part also from synthetic gases from coal, due to technical differences from conventional coal sources and due to the impermanence of this change, we still do not list Estonia among the coal countries).
+* Others of these states are not self-sufficient in electricity generation. In 2019, Luxembourg imported more than 70% of its electricity consumption, Lithuania more than 65% and Malta 35%. In all cases, this lack of self-sufficiency is due to the decommissioning of previous (obsolete) electricity sources and the lack of construction of new sources.
+
+We cannot speak directly of a coal phase-out for these countries because the energy transition will take place in a different way.
+
+**The impact of coal power plants on global climate change** – according to 2017 data from the [IEA](https://www.iea.org/data-and-statistics?country=WORLD&fuel=CO2%20emissions&indicator=CO2%20emissions%20from%20electricity%20and%20heat%20by%20energy%20source) and [ourworldindata.org](https://ourworldindata.org/co2-and-other-greenhouse-gas-emissions#co2-emissions-by-fuel), emissions from coal combustion account for approximately 40% of total global CO<sub>2</sub> emissions (not <glossary id="co2eq">CO<sub>2</sub>eq</glossary>). If we are talking exclusively about coal and thermal power plants, this share is about 27%.
+
+**The timeframe for meeting the targets of the Paris Climate Agreement** – the time horizon is addressed in the 2017 study [_A stress test for coal in Europe under the Paris Agreement_](https://climateanalytics.org/media/eu_coal_stress_test_report_2017.pdf) (Stress test for coal in Europe due to the Paris Agreement on climate protection). The stress test was developed in 2017 by the German organization Climate Analytics. The study states that it is necessary to shut down all European coal power plants by 2030 to achieve the goals of the Paris Agreement.
+
+**What sources are used to replace coal in electricity generation?** In the US, coal has been largely replaced by natural gas and in the EU, mainly by renewables.<!-- For details, see the related infographic on [electricity generation in world regions](/elektrina-svet).--> A coal phase-out does not necessarily mean the closure of all current coal plants. Across Europe, some coal plants are being converted to natural gas or biomass. (Note: natural gas has about half the emission intensity of coal. For biomass, the emission intensity depends on how the biomass is produced and transported; the combustion of naturally grown biomass itself is carbon neutral).
+
+**What would be the impact of the closure of Czech coal power plants by 2030 on the stability of the electricity system?** See our extract from a related [study by Energynautics](/studies/2018-scenario-energynautics).
+
+**What are the specific mechanisms through which a coal phase-out can be implemented?**
+
+* **By charging emissions across many sectors** – <!--within the EU, energy is included in the [trading of emission allowances (EU ETS)](/explainery/emisni-povolenky-ets), in which the Czech Republic also participates as a member state.--> Due to changes in the scheme and the European Union's higher climate ambition, the price per tonne of CO2 has risen significantly in recent years from around €10 at the start of 2018 to [€80](https://ember-climate.org/carbon-price-viewer/) in December 2021, significantly increasing the pressure to reduce emissions in the sectors covered. At the end of 2021, the energy crisis also contributed to higher allowance prices, as extremely expensive natural gas led to a return to more coal-fired power generation (and thus increased demand for allowances due to higher coal emissions). If the price of allowances remains at a comparable level after the energy crisis has passed, coal power plants will not be competitive in the long term and a coal phase-out is likely to occur within a few years purely for economic reasons.
+* **Limiting subsidies** – at the EU level, for example, [there has been](https://www.iisd.org/sites/default/files/publications/stories-g20-eu-en.pdf) a complete ban on subsidies for coal mining (from 2018) and further pressure to reduce all subsidies for fossil fuel extraction and combustion.
+* **Additional carbon tax in the energy sector** beyond the EU ETS (e.g. introduced in the UK in 2013, currently calculated at about [€20 per tonne of CO<sub>2</sub>](https://phys.org/news/2020-01-british-carbon-tax-coal-fired-electricity.html)).
+* **Legal limitation of emission intensity for power plants** (e.g., in France, it will be in force from 2022).
+* **An outright ban on coal power plants** (e.g. in Finland from May 2029 or in the Netherlands from January 2030).
+* **Paying compensation to operators of coal power plants** (planned in Germany partly through fixed compensation and partly through auctions; Finland offers operators a symbolic compensation if they stop production 5 years earlier than the law prohibits it).
+* **Through structural support** for affected coal regions (e.g. planned in Germany, Spain and France).
+
+## Data source
+
+* The infographic is based on data from [Ember](https://ember-climate.org/) (formerly called Sandbag). Ember is an independent climate think-tank dedicated to promoting the transition from coal to clean sources of electricity.
+* For EU countries, Ember is primarily based on Eurostat data. Data for 2018 and 2019 (for which official Eurostat statistics are not yet available) are based on the organisation's analytical work, based on data from the European Network of Transmission System Operators for Electricity (ENTSO-E) and other sources. These data are, therefore, their best possible estimates of the actual situation as captured later by Eurostat. Experience shows that these estimates capture reality very accurately, with deviations of a few tenths of a per cent of total electricity production.
+* One of the main activities of the Ember think tank is the publication of reports on electricity production in the European Union. In 2020, it also published a report on global electricity production<!--, a summary of which can be found [in studies](/studie/2020-globalni-zprava-o-elektrine)-->. This infographic is based on the dataset that was attached to this report.
+* The overview of phase-out dates is based on research by Europe Beyond Coal called [Coal Exit Tracker](https://beyond-coal.eu/coal-exit-tracker/?type=maps&layer=4). We have refined some data based on our research.
+* Population data is taken from the United Nations.


### PR DESCRIPTION
Task of #14: Add English texts to the published infographics

### Preview Build

Current preview build is available at https://en-facts-on-climate--preview-coal-phase-out-eu-d6pext7r.web.app/infographics/coal-phase-out-eu

### What does this PR do?

- bulk-translated the Czech text to English using [DeepL](https://www.deepl.com)
- Use [Grammarly](https://www.grammarly.com/) to proofread the texts.
- Note: this is branched off of efc31f4a3dca4972596792d34d0e3a3aa95fbfc9 which introduced the glossary and `co2eq` for #17

  ### Commented out links:
- Commented out link in text (using html comments) as these are (not yet) available in English:
  - [elektrina-svet - https://faktaoklimatu.cz/infografiky/elektrina-svet](https://faktaoklimatu.cz/infografiky/elektrina-svet)
  - [explainery/emisni-povolenky-ets - https://faktaoklimatu.cz/explainery/emisni-povolenky-ets](https://faktaoklimatu.cz/explainery/emisni-povolenky-ets)
  - [studie/2020-globalni-zprava-o-elektrine - https://faktaoklimatu.cz/studie/2020-globalni-zprava-o-elektrine](https://faktaoklimatu.cz/studie/2020-globalni-zprava-o-elektrine)